### PR TITLE
Remove unstable_handleError

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0-alpha.13",
-    "react-dom": "^16.0.0-alpha.13"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0-beta.1",
+    "react-dom": "^16.0.0-beta.1"
   }
 }

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -35,11 +35,6 @@ class ErrorBoundary extends Component {
     };
   }
 
-  unstable_handleError(error: Error, info: ErrorInfo):void {
-    // This method is a fallback for react <= 16.0.0-alpha.13
-    this.componentDidCatch(error, info);
-  }
-
   componentDidCatch(error: Error, info: ErrorInfo):void {
     const {onError} = this.props;
 


### PR DESCRIPTION
`componentDidCatch` is supported by React16, so we should remove `unstable_handleError`.