### PR TITLE
withErrorBoundary decorator function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-loader": "^7.1.1",
     "babel-runtime": "^6.23.0",
     "prop-types": "^15.5.10",
+    "react": "^16.0.0",
     "webpack": "^3.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-loader": "^7.1.1",
     "babel-runtime": "^6.23.0",
     "prop-types": "^15.5.10",
-    "react": "^16.0.0",
     "webpack": "^3.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,7 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-runtime": "^6.23.0",
-    "flow-bin": "^0.57.3",
     "prop-types": "^15.5.10",
-    "react": "^16.0.0",
     "webpack": "^3.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-runtime": "^6.23.0",
+    "flow-bin": "^0.57.3",
     "prop-types": "^15.5.10",
+    "react": "^16.0.0",
     "webpack": "^3.3.0"
   },
   "peerDependencies": {

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -66,4 +66,16 @@ class ErrorBoundary extends Component {
   }
 }
 
+
+export const withErrorBoundary: Function = (
+    Component: *,
+    FallbackComponent: *,
+    onError: Function
+): Function => (props: *): * => (
+        <ErrorBoundary FallbackComponent={FallbackComponent} onError={onError}>
+            <Component {...props} />
+        </ErrorBoundary>
+    );
+
+
 export default ErrorBoundary;

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -16,11 +16,13 @@ type ErrorInfo = {
 type State = {
   error: ?Error,
   info: ?ErrorInfo,
-};
+}
 
-class ErrorBoundary extends Component {
+class ErrorBoundary extends Component<Props, State> {
   props: Props;
   state: State;
+
+  setState: Function
 
   static defaultProps = {
     FallbackComponent: ErrorBoundaryFallbackComponent,
@@ -68,10 +70,10 @@ class ErrorBoundary extends Component {
 
 
 export const withErrorBoundary: Function = (
-    Component: *,
-    FallbackComponent: *,
+    Component: Class<React.Component<*>>,
+    FallbackComponent: Class<React.Component<*>>,
     onError: Function
-): Function => (props: *): * => (
+): Function => props => (
         <ErrorBoundary FallbackComponent={FallbackComponent} onError={onError}>
             <Component {...props} />
         </ErrorBoundary>

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -16,7 +16,7 @@ type ErrorInfo = {
 type State = {
   error: ?Error,
   info: ?ErrorInfo,
-}
+};
 
 class ErrorBoundary extends Component<Props, State> {
   props: Props;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /** @flow */
 
 import ErrorBoundaryFallbackComponent from './ErrorBoundaryFallbackComponent';
-import ErrorBoundary from './ErrorBoundary';
+import ErrorBoundary, { withErrorBoundary } from './ErrorBoundary';
 
 export default ErrorBoundary;
-export {ErrorBoundary, ErrorBoundaryFallbackComponent};
+export {ErrorBoundary, withErrorBoundary, ErrorBoundaryFallbackComponent};


### PR DESCRIPTION
This serves the use case outlined in this issue: https://github.com/bvaughn/react-error-boundary/issues/4

@bvaughn How about adding React flow types to make the typing on the function a bit tighter than *?