### PR TITLE
Add repository and hompage fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "react-error-boundary",
   "version": "1.2.0",
   "description": "Sample reusable React error boundary component for React 16+",
+  "homepage": "https://github.com/bvaughn/react-error-boundary",
+  "repository": "bvaughn/react-error-boundary",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
So npm page will have a link to the repo: https://www.npmjs.com/package/react-error-boundary