### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export interface FallbackProps {
+  error?: Error;
+  componentStack?: string;
+}
+
+export interface ErrorBoundaryProps {
+  onError?: (error: Error, componentStack: string) => void;
+  FallbackComponent?: React.ComponentType<FallbackProps>;
+}
+
+export function withErrorBoundary<P>(
+  ComponentToDecorate: React.ComponentType<P>,
+  CustomFallbackComponent?: React.ComponentType<FallbackProps>,
+  onErrorHandler?: (error: Error, componentStack: string) => void,
+): React.ComponentType<P>;
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps>{}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "homepage": "https://github.com/bvaughn/react-error-boundary",
   "repository": "bvaughn/react-error-boundary",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "main": "dist/commonjs/index.js",
   "scripts": {


### PR DESCRIPTION
`react-error-boundary` is a small library that is unlikely to change much, so I think it makes sense to publish definitions alongside the library (and not on DefinitelyTyped)