### PR TITLE
Update withErrorBoundary HOC signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,8 @@ export interface ErrorBoundaryProps {
 }
 
 export function withErrorBoundary<P>(
-  ComponentToDecorate: React.ComponentType<P>,
   CustomFallbackComponent?: React.ComponentType<FallbackProps>,
   onErrorHandler?: (error: Error, componentStack: string) => void,
-): React.ComponentType<P>;
+): (BaseComponent: React.ComponentType<P>) => React.ComponentType<P>;
 
 export default class ErrorBoundary extends React.Component<ErrorBoundaryProps>{}

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -60,12 +60,11 @@ class ErrorBoundary extends Component<Props, State> {
 }
 
 export const withErrorBoundary = (
-  Component: ComponentType<any>,
   FallbackComponent: ComponentType<any>,
   onError: Function,
-): Function => props => (
+): Function => (BaseComponent: ComponentType<any>) => props => (
   <ErrorBoundary FallbackComponent={FallbackComponent} onError={onError}>
-    <Component {...props} />
+    <BaseComponent {...props} />
   </ErrorBoundary>
 );
 


### PR DESCRIPTION
This updates the `withErrorBoundary` HOC to return a function that receives the base component.

This makes it easier to compose `withErrorBoundary` with other HOCs, like this:

```js
compose(
  withErrorBoundary(MyErrorComponent),
  connect(mapStateToProps)
)(MyComponent);
```