### PR TITLE
Allow the component to recover on props change

### DIFF
--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -41,6 +41,13 @@ class ErrorBoundary extends Component<Props, State> {
 
     this.setState({error, info});
   }
+  
+  componentWillReceiveProps() {
+    this.setState({
+      error: null,
+      info: null
+    });
+  }
 
   render() {
     const {children, FallbackComponent} = this.props;


### PR DESCRIPTION
A component may throw an error from time to time due to broken data and therefore broken assumptions in the component. 
I think it might be beneficial to be able to recover from the broken state in case the data has changed without the need to reload the page/app.

Since the developers should be notified about the error at the point this will reduce the time a customer will see the broken/non-working component.