### PR TITLE
Annotate return types of render methods with React.Node

### DIFF
--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,6 +1,7 @@
 /** @flow */
 
 import React, {Component} from 'react';
+import type {Node} from 'react';
 import ErrorBoundaryFallbackComponent from './ErrorBoundaryFallbackComponent';
 
 import type {ComponentType} from 'react';
@@ -43,7 +44,7 @@ class ErrorBoundary extends Component<Props, State> {
     this.setState({error, info});
   }
 
-  render() {
+  render(): Node {
     const {children, FallbackComponent} = this.props;
     const {error, info} = this.state;
 

--- a/src/ErrorBoundaryFallbackComponent.js
+++ b/src/ErrorBoundaryFallbackComponent.js
@@ -1,6 +1,7 @@
 /** @flow */
 
 import React from 'react';
+import type {Node} from 'react';
 
 type Props = {
   componentStack: string,
@@ -11,7 +12,7 @@ const toTitle = (error: Error, componentStack: string): string => {
   return `${error.toString()}\n\nThis is located at:${componentStack}`;
 };
 
-const ErrorBoundaryFallbackComponent = ({componentStack, error}: Props) => (
+const ErrorBoundaryFallbackComponent = ({componentStack, error}: Props): Node => (
   <div style={style} title={toTitle(error, componentStack)}>
     <svg style={svgStyle} viewBox="0 0 24 24" preserveAspectRatio="xMidYMid">
       <path


### PR DESCRIPTION
### Summary

This PR adds [`React.Node`](https://flow.org/en/docs/react/types/#toc-react-node) FlowTypes to annotate the return types of `ErrorBoundary.render`, and `ErrorBoundaryFallbackComponent`.