### PR TITLE
removes unused prop-types devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "flow-bin": "^0.57.3",
     "jest": "^23.5.0",
     "prettier": "^1.7.4",
-    "prop-types": "^15.5.10",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-test-renderer": "^16.4.2",


### PR DESCRIPTION
As far as I can tell this is not used anywhere in this project.

Also, [`babel-plugin-flow-react-proptypes`](https://github.com/brigand/babel-plugin-flow-react-proptypes/blob/master/package.json) and [`babel-plugin-transform-react-remove-prop-types`](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/blob/master/package.json) both don't seem to require it (or, interestingly, even use it themselves).