### PR TITLE
Update README to used named export for ErrorBoundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ that may throw an error. This will handle errors thrown by that component and
 its descendants too.
 
 ```jsx
-import ErrorBoundary from 'react-error-boundary'
+import {ErrorBoundary} from 'react-error-boundary'
 
 function ErrorFallback({error, componentStack}) {
   return (
@@ -82,7 +82,7 @@ const ui = (
 You can react to errors (e.g. for logging) by providing an `onError` callback:
 
 ```jsx
-import ErrorBoundary from 'react-error-boundary'
+import {ErrorBoundary} from 'react-error-boundary'
 
 const myErrorHandler = (error: Error, componentStack: string) => {
   // Do something with the error


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: It looks like with version 2, `ErrorBoundary` has changed to a named export. The docs show 
```javascript
import ErrorBoundary from 'react-error-boundary'
```
when it should be
```javascript
import { ErrorBoundary } from 'react-error-boundary'
```

<!-- Why are these changes necessary? -->

**Why**: The current documentation is incorrect, so those upgrading will receive any error.

<!-- How were these changes implemented? -->

**How**: Just a simple documentation update.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
