### PR TITLE
feat(onReset): pass arguments to onReset callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ state (which will result in rendering the `children` again). You should use this
 to ensure that re-rendering the children will not result in a repeat of the same
 error happening again.
 
+`onReset` will be called with whatever `resetErrorBoundary` is called with. In
+the case of `resetKeys`, it's called with the `prevResetKeys` and the
+`resetKeys`. This can help you differentiate between a reset that occurred due
+to a "try again" button click and one trigged by a `resetKeys` change.
+
 ### `resetKeys`
 
 Sometimes an error happens as a result of local state to the component that's

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,8 @@ const changedArray = (a = [], b = []) =>
 const initialState = {error: null, info: null}
 class ErrorBoundary extends React.Component {
   state = initialState
-  resetErrorBoundary = () => {
-    this.props.onReset?.()
+  resetErrorBoundary = (...args) => {
+    this.props.onReset?.(...args)
     this.setState(initialState)
   }
 
@@ -20,7 +20,7 @@ class ErrorBoundary extends React.Component {
     const {error} = this.state
     const {resetKeys} = this.props
     if (error !== null && changedArray(prevProps.resetKeys, resetKeys)) {
-      this.resetErrorBoundary()
+      this.resetErrorBoundary(prevProps.resetKeys, resetKeys)
     }
   }
 


### PR DESCRIPTION
**What**: pass arguments to onReset callback

Whatever is passed to `resetErrorBoundary` will be forwarded along to `onReset`. In the case of `resetKeys` it'll be passed the previous resetKeys and the current `resetKeys`.

**Why**:

This will allow users to differentiate what triggered the reset so they
know how to proceed with their recovery.

**How**:

1. Take the args in `resetErrorBoundary` and forward them to the `onReset` call.
2. Pass the `prevProps.resetKeys` and `this.props.resetKeys` to `resetErrorBoundary`

Not sure how to type this with TypeScript so I'll wait for someone to fix that up later.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
