### PR TITLE
Compare length of resetKeys when checking if resetKeys has changed

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -328,14 +328,18 @@ test('supports automatic reset of error boundary when resetKeys change', () => {
   expect(console.error).toHaveBeenCalledTimes(2)
   console.error.mockClear()
 
-  // check it calls onResetKeysChange if resetKeys length changes
+  // toggles adding an extra resetKey to the array
+  // expect error to re-render
   userEvent.click(screen.getByText('toggle extra resetKey'))
   expect(handleResetKeysChange).toHaveBeenCalledTimes(1)
   expect(handleResetKeysChange).toHaveBeenCalledWith([true], [true, true])
   handleResetKeysChange.mockClear()
+  screen.getByRole('alert')
   expect(console.error).toHaveBeenCalledTimes(2)
   console.error.mockClear()
-  screen.getByRole('alert')
+
+  // toggle explode back to false
+  // expect error to re-render again
   userEvent.click(screen.getByText('toggle explode'))
   expect(handleReset).not.toHaveBeenCalled()
   expect(handleResetKeysChange).toHaveBeenCalledTimes(1)
@@ -343,10 +347,13 @@ test('supports automatic reset of error boundary when resetKeys change', () => {
     [true, true],
     [false, true],
   )
+  screen.getByRole('alert')
   handleResetKeysChange.mockClear()
   expect(console.error).toHaveBeenCalledTimes(2)
-  screen.getByRole('alert')
   console.error.mockClear()
+
+  // toggle extra resetKey
+  // expect error to be reset
   userEvent.click(screen.getByText('toggle extra resetKey'))
   expect(handleReset).not.toHaveBeenCalled()
   expect(handleResetKeysChange).toHaveBeenCalledTimes(1)

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const changedArray = (a = [], b = []) =>
-  a.some((item, index) => !Object.is(item, b[index]))
+  a.length !== b.length || a.some((item, index) => !Object.is(item, b[index]))
 
 const initialState = {error: null, info: null}
 class ErrorBoundary extends React.Component {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

When determining whether to reset state/call `onResetKeysChange` callback, also checks if the length of the `resetKeys` dependency array changes.

<!-- Why are these changes necessary? -->

**Why**:

Edge case where `resetKeys` array is computed dynamically and its length could change.

<!-- How were these changes implemented? -->

**How**:

Added a length comparison check to `changedArray`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
