### PR TITLE
point package.json types property to including type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/react-error-boundary.cjs.js",
   "module": "dist/react-error-boundary.esm.js",
   "browser": "dist/react-error-boundary.umd.js",
+  "types": "index.d.ts",
   "sideEffects": false,
   "keywords": [
     "react",


### PR DESCRIPTION
**What**:

I do get an eslint error `FallbackProps not found in 'react-error-boundary'  import/named` with `eslint-import-resolver-typescript` as it seems that the built js bundles gets favored over the included types. 

**Why**:

I'm aware that the problem might be related to how `eslint-import-resolver-typescript` is trying to resolve the types, but adding the the `types` prop in package.json fixes the issue and is advised by the typescript team anyways. 

**How**:

point the `types` prop in package.json to the declaration file.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
