### PR TITLE
fix: FallbackComponent type

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,11 @@
     "@testing-library/user-event": "^12.0.11",
     "kcd-scripts": "^6.2.4",
     "react": "^16.13.1",
-    "react-is": "^16.13.1",
     "react-dom": "^16.13.1",
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "react": ">=16.13.1",
-    "react-is": ">=16.13.1"
+    "react": ">=16.13.1"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "@testing-library/user-event": "^12.0.11",
     "kcd-scripts": "^6.2.4",
     "react": "^16.13.1",
+    "react-is": "^16.13.1",
     "react-dom": "^16.13.1",
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "react": ">=16.13.1"
+    "react": ">=16.13.1",
+    "react-is": ">=16.13.1"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -348,3 +348,34 @@ test('supports automatic reset of error boundary when resetKeys change', () => {
   expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   expect(console.error).not.toHaveBeenCalled()
 })
+
+test('should support not only function as FallbackComponent', () => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  ;[React.forwardRef, React.memo, component => component].forEach(
+    componentCreator => {
+      const FancyFallback = componentCreator(({error}) => (
+        <div>
+          <p>Everything is broken. Try again</p>
+          <pre>{error.message}</pre>
+        </div>
+      ))
+      expect(() =>
+        render(
+          <ErrorBoundary FallbackComponent={FancyFallback}>
+            <Bomb />
+          </ErrorBoundary>,
+          {
+            container,
+          },
+        ),
+      ).not.toThrow()
+
+      expect(
+        screen.getByText('Everything is broken. Try again'),
+      ).toBeInTheDocument()
+    },
+  )
+
+  console.error.mockClear()
+})

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -379,3 +379,15 @@ test('should support not only function as FallbackComponent', () => {
 
   console.error.mockClear()
 })
+
+test('should throw error if FallbackComponent is not valid', () => {
+  expect(() =>
+    render(
+      <ErrorBoundary FallbackComponent={{}}>
+        <Bomb />
+      </ErrorBoundary>,
+    ),
+  ).toThrowError(/Element type is invalid/i)
+
+  console.error.mockClear()
+})

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -350,32 +350,25 @@ test('supports automatic reset of error boundary when resetKeys change', () => {
 })
 
 test('should support not only function as FallbackComponent', () => {
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  ;[React.forwardRef, React.memo, component => component].forEach(
-    componentCreator => {
-      const FancyFallback = componentCreator(({error}) => (
-        <div>
-          <p>Everything is broken. Try again</p>
-          <pre>{error.message}</pre>
-        </div>
-      ))
-      expect(() =>
-        render(
-          <ErrorBoundary FallbackComponent={FancyFallback}>
-            <Bomb />
-          </ErrorBoundary>,
-          {
-            container,
-          },
-        ),
-      ).not.toThrow()
+  const FancyFallback = React.forwardRef(({error}) => (
+    <div>
+      <p>Everything is broken. Try again</p>
+      <pre>{error.message}</pre>
+    </div>
+  ))
+  FancyFallback.displayName = 'FancyFallback'
 
-      expect(
-        screen.getByText('Everything is broken. Try again'),
-      ).toBeInTheDocument()
-    },
-  )
+  expect(() =>
+    render(
+      <ErrorBoundary FallbackComponent={FancyFallback}>
+        <Bomb />
+      </ErrorBoundary>,
+    ),
+  ).not.toThrow()
+
+  expect(
+    screen.getByText('Everything is broken. Try again'),
+  ).toBeInTheDocument()
 
   console.error.mockClear()
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import {isValidElementType} from 'react-is'
 
 const changedArray = (a = [], b = []) =>
   a.length !== b.length || a.some((item, index) => !Object.is(item, b[index]))
@@ -40,7 +39,7 @@ class ErrorBoundary extends React.Component {
         return fallback
       } else if (typeof fallbackRender === 'function') {
         return fallbackRender(props)
-      } else if (isValidElementType(FallbackComponent)) {
+      } else if (FallbackComponent) {
         return <FallbackComponent {...props} />
       } else {
         throw new Error(

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {isValidElementType} from 'react-is'
 
 const changedArray = (a = [], b = []) =>
   a.length !== b.length || a.some((item, index) => !Object.is(item, b[index]))
@@ -39,7 +40,7 @@ class ErrorBoundary extends React.Component {
         return fallback
       } else if (typeof fallbackRender === 'function') {
         return fallbackRender(props)
-      } else if (typeof FallbackComponent === 'function') {
+      } else if (isValidElementType(FallbackComponent)) {
         return <FallbackComponent {...props} />
       } else {
         throw new Error(


### PR DESCRIPTION

fix #61 
**What**: React Component can be function but also objects. To check if a component is a real one I have used `react-is` 

<!-- Why are these changes necessary? -->

**Why**: Because with `styled-components` the `ErrorBoundary` threw an error

<!-- How were these changes implemented? -->

**How**: using a library from Facebook `react-is`
 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
