### PR TITLE
Update TS Types for v3 Breaking Change

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react'
 
 export interface FallbackProps {
   error?: Error
-  componentStack?: string
   resetErrorBoundary: () => void
 }
 


### PR DESCRIPTION
**What**:

Updates the `index.d.ts` file to match the changes made in [the v3 release](https://github.com/bvaughn/react-error-boundary/releases/tag/v3.0.0):

>  This removes the `componentStack` in the props given to the `FallbackComponent` and `fallbackRender`


**Why**:

Because the types in `index.d.ts` were incompatible with the new v3 API, resulting in unsafe typings.

<!-- How were these changes implemented? -->

**How**:

Removes the `componentStack` property from the `FallbackProps` type.

**Checklist**:

- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x]  Ready to be merged