### PR TITLE
Fix TypeScript types for onError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface FallbackProps {
 export interface ErrorBoundaryPropsWithComponent {
   onResetKeysChange?: (prevResetKeys: Array<any>, resetKeys: Array<any>) => void
   onReset?: () => void
-  onError?: (error: Error, componentStack: string) => void
+  onError?: (error: Error, info: { componentStack: string }) => void
   resetKeys?: Array<any>
   FallbackComponent: React.ComponentType<FallbackProps>
 }
@@ -16,7 +16,7 @@ export interface ErrorBoundaryPropsWithComponent {
 export interface ErrorBoundaryPropsWithRender {
   onResetKeysChange?: (prevResetKeys: Array<any>, resetKeys: Array<any>) => void
   onReset?: () => void
-  onError?: (error: Error, componentStack: string) => void
+  onError?: (error: Error, info: { componentStack: string }) => void
   resetKeys?: Array<any>
   fallbackRender: (props: FallbackProps) => React.ReactElement<any, any> | null
 }
@@ -24,7 +24,7 @@ export interface ErrorBoundaryPropsWithRender {
 export interface ErrorBoundaryPropsWithFallback {
   onResetKeysChange?: (prevResetKeys: Array<any>, resetKeys: Array<any>) => void
   onReset?: () => void
-  onError?: (error: Error, componentStack: string) => void
+  onError?: (error: Error, info: { componentStack: string }) => void
   resetKeys?: Array<any>
   fallback: React.ReactElement<any, any> | null
 }


### PR DESCRIPTION
**What**:

Update the type definitions to match the data passed to onError.

**Why**:

onError is passed the whole "info" object from componentDidCatch and not just the componentStack. The README has the correct types in an example, but the type definitions are incorrect.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged

