### PR TITLE
fix: ignored update after error triggered on component mount 

### DIFF
--- a/src/__tests__/hook.tsx
+++ b/src/__tests__/hook.tsx
@@ -46,9 +46,9 @@ test('handleError forwards along async errors', async () => {
     `"Error: Uncaught [Error: 💥 CABOOM 💥]"`,
   )
   expect(componentStack).toMatchInlineSnapshot(`
-    "The above error occurred in one of your React components:
+    "The above error occurred in the <AsyncBomb> component:
 
-        at <PROJECT_ROOT>/src/__tests__/hook.tsx:21:41
+        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:21:41)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
@@ -92,9 +92,9 @@ test('can pass an error to useErrorHandler', async () => {
     `"Error: Uncaught [Error: 💥 CABOOM 💥]"`,
   )
   expect(componentStack).toMatchInlineSnapshot(`
-    "The above error occurred in one of your React components:
+    "The above error occurred in the <AsyncBomb> component:
 
-        at <PROJECT_ROOT>/src/__tests__/hook.tsx:66:37
+        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:66:37)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -351,6 +351,43 @@ test('supports automatic reset of error boundary when resetKeys change', () => {
   expect(consoleError).not.toHaveBeenCalled()
 })
 
+test('supports reset via resetKeys right after error is triggered on component mount', () => {
+  const consoleError = console.error as jest.Mock<void, unknown[]>
+  const handleResetKeysChange = jest.fn()
+  function App() {
+    const [explode, setExplode] = React.useState(true)
+    return (
+      <div>
+        <button onClick={() => setExplode(e => !e)}>toggle explode</button>
+        <ErrorBoundary
+          fallbackRender={() => (
+            <div role="alert">
+              <p>Something went wrong</p>
+            </div>
+          )}
+          onResetKeysChange={handleResetKeysChange}
+          resetKeys={[explode]}
+        >
+          {explode ? <Bomb /> : null}
+        </ErrorBoundary>
+      </div>
+    )
+  }
+  render(<App />)
+
+  // it blows up on render
+  expect(screen.getByRole('alert')).toBeInTheDocument()
+  expect(consoleError).toHaveBeenCalledTimes(2)
+  consoleError.mockClear()
+
+  // recover via "toggle explode" button
+  userEvent.click(screen.getByText('toggle explode'))
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  expect(consoleError).not.toHaveBeenCalled()
+  expect(handleResetKeysChange).toHaveBeenCalledWith([true], [false])
+  expect(handleResetKeysChange).toHaveBeenCalledTimes(1)
+})
+
 test('should support not only function as FallbackComponent', () => {
   const consoleError = console.error as jest.Mock<void, unknown[]>
 

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -60,7 +60,7 @@ test('standard use-case', () => {
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
         at div
         at div
-        at <PROJECT_ROOT>/src/__tests__/index.tsx:28:43
+        at App (<PROJECT_ROOT>/src/__tests__/index.tsx:28:43)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,6 +84,14 @@ class ErrorBoundary extends React.Component<
     this.props.onError?.(error, info)
   }
 
+  componentDidMount() {
+    const {error} = this.state
+
+    if (error !== null) {
+      this.updatedWithError = true
+    }
+  }
+
   componentDidUpdate(prevProps: ErrorBoundaryProps) {
     const {error} = this.state
     const {resetKeys} = this.props


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Fix ignored update via `resetKeys` after `ErrorBoundary` error state is triggered on component mount. 
- Add test for this case.
- I also needed to update a couple of snapshots to make it. That was strange to me.

**Why**:

Closes #74 and Closes #84

<!-- How were these changes implemented? -->

**How**:

Adding extra check of `this.updatedWithError` on `componentDidMount`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
