### PR TITLE
useErrorHandler: use unknown instead of Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ See the recovery examples above.
 This is called when the `resetKeys` are changed (triggering a reset of the
 `ErrorBoundary`). It's called with the `prevResetKeys` and the `resetKeys`.
 
-### `useErrorHandler(error?: Error)`
+### `useErrorHandler(error?: unknown)`
 
 React's error boundaries feature is limited in that the boundaries can only
 handle errors thrown during React's lifecycles. To quote

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -159,12 +159,10 @@ function withErrorBoundary<P>(
   return Wrapped
 }
 
-function useErrorHandler<P = Error>(
-  givenError?: P | null | undefined,
-): React.Dispatch<React.SetStateAction<P | null>> {
-  const [error, setError] = React.useState<P | null>(null)
-  if (givenError) throw givenError
-  if (error) throw error
+function useErrorHandler(givenError?: unknown): (error: unknown) => void {
+  const [error, setError] = React.useState<unknown>(null)
+  if (givenError != null) throw givenError
+  if (error != null) throw error
   return setError
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

In the useErrorHandler hook, i've changed the type of the error from `Error` to `unknown`.

**What**:

Not all thrown exceptions are of type `Error`, see #83 for a discussion concerning this change

**Why**:
NA

<!-- How were these changes implemented? -->

**How**:

I've made the changes as agreed upon and also corrected the documentation

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I've noticed that current master has a linting issue on the fallback in the render method, i'll take a look at it