### PR TITLE
fix(TS): help typescript to find his way for the ErrorBoundaryProps

### DIFF
--- a/src/__tests__/hook.tsx
+++ b/src/__tests__/hook.tsx
@@ -49,7 +49,7 @@ test('handleError forwards along async errors', async () => {
     "The above error occurred in the <AsyncBomb> component:
 
         at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:21:41)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)
@@ -95,7 +95,7 @@ test('can pass an error to useErrorHandler', async () => {
     "The above error occurred in the <AsyncBomb> component:
 
         at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:66:37)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -57,7 +57,7 @@ test('standard use-case', () => {
     "The above error occurred in the <Bomb> component:
 
         at Bomb (<PROJECT_ROOT>/src/__tests__/index.tsx:18:9)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at div
         at div
         at App (<PROJECT_ROOT>/src/__tests__/index.tsx:28:43)
@@ -162,7 +162,7 @@ test('withErrorBoundary HOC', () => {
     "The above error occurred in one of your React components:
 
         at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:150:13)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at withErrorBoundary(Unknown)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
@@ -178,7 +178,7 @@ test('withErrorBoundary HOC', () => {
     Object {
       "componentStack": "
         at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:150:13)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:66:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at withErrorBoundary(Unknown)",
     }
   `)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,9 @@ interface ErrorBoundaryPropsWithComponent {
   onReset?: (...args: Array<unknown>) => void
   onError?: (error: Error, info: {componentStack: string}) => void
   resetKeys?: Array<unknown>
+  fallback?: never
   FallbackComponent: React.ComponentType<FallbackProps>
+  fallbackRender?: never
 }
 
 declare function FallbackRender(
@@ -34,6 +36,8 @@ interface ErrorBoundaryPropsWithRender {
   onReset?: (...args: Array<unknown>) => void
   onError?: (error: Error, info: {componentStack: string}) => void
   resetKeys?: Array<unknown>
+  fallback?: never
+  FallbackComponent?: never
   fallbackRender: typeof FallbackRender
 }
 
@@ -49,6 +53,8 @@ interface ErrorBoundaryPropsWithFallback {
     unknown,
     string | React.FunctionComponent | typeof React.Component
   > | null
+  FallbackComponent?: never
+  fallbackRender?: never
 }
 
 type ErrorBoundaryProps =
@@ -115,7 +121,7 @@ class ErrorBoundary extends React.Component<
 
   render() {
     const {error} = this.state
-    // @ts-expect-error ts(2339) (at least one of these will be defined though, and we check for their existence)
+
     const {fallbackRender, FallbackComponent, fallback} = this.props
 
     if (error !== null) {
@@ -126,7 +132,7 @@ class ErrorBoundary extends React.Component<
       if (React.isValidElement(fallback)) {
         return fallback
       } else if (typeof fallbackRender === 'function') {
-        return (fallbackRender as typeof FallbackRender)(props)
+        return fallbackRender(props)
       } else if (FallbackComponent) {
         return <FallbackComponent {...props} />
       } else {


### PR DESCRIPTION
…nion

This fixes a lot of issue concerning the union and ensures typescript which is which

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Assist typescript in union type of `ErrorBoundaryProps` and cleanup related leftovers

<!-- Why are these changes necessary? -->

**Why**: A linting error was present on master

<!-- How were these changes implemented? -->

**How**: NA

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation NA
- [X] Tests
- [X ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Snapshots needed updating because of the stacktrace changes