### PR TITLE
refactor: remove `updatedWithError` class instance property

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,14 +75,12 @@ class ErrorBoundary extends React.Component<
   }
 
   state = initialState
-  updatedWithError = false
   resetErrorBoundary = (...args: Array<unknown>) => {
     this.props.onReset?.(...args)
     this.reset()
   }
 
   reset() {
-    this.updatedWithError = false
     this.setState(initialState)
   }
 
@@ -90,15 +88,10 @@ class ErrorBoundary extends React.Component<
     this.props.onError?.(error, info)
   }
 
-  componentDidMount() {
-    const {error} = this.state
-
-    if (error !== null) {
-      this.updatedWithError = true
-    }
-  }
-
-  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+  componentDidUpdate(
+    prevProps: ErrorBoundaryProps,
+    prevState: ErrorBoundaryState,
+  ) {
     const {error} = this.state
     const {resetKeys} = this.props
 
@@ -108,12 +101,12 @@ class ErrorBoundary extends React.Component<
     // error to be thrown.
     // So we make sure that we don't check the resetKeys on the first call
     // of cDU after the error is set
-    if (error !== null && !this.updatedWithError) {
-      this.updatedWithError = true
-      return
-    }
 
-    if (error !== null && changedArray(prevProps.resetKeys, resetKeys)) {
+    if (
+      error !== null &&
+      prevState.error !== null &&
+      changedArray(prevProps.resetKeys, resetKeys)
+    ) {
       this.props.onResetKeysChange?.(prevProps.resetKeys, resetKeys)
       this.reset()
     }
@@ -183,6 +176,7 @@ export type {
 
 /*
 eslint
+  @typescript-eslint/sort-type-union-intersection-members: "off",
   @typescript-eslint/no-throw-literal: "off",
   @typescript-eslint/prefer-nullish-coalescing: "off"
 */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: removed the `updatedWithError` class instance property, and replaced with checking `prevState.error` in `componentDidUpdate`.

<!-- Why are these changes necessary? -->

**Why**: i have found the `this.updatedWithError` a bit confusing to follow, and afaict checking `prevState.error` wlil do the same since we only want to avoid resetting the error state in the same render cycle where we received the error. tests are still passing, but feel free to close if you think this doesn't add anything.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A (still passing)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

also added eslint comment to disable sorting typescript union members, to keep the diff clear