### PR TITLE
fix: FallbackProps error type

### DIFF
--- a/src/__tests__/hook.tsx
+++ b/src/__tests__/hook.tsx
@@ -8,7 +8,11 @@ function ErrorFallback({error, resetErrorBoundary}: FallbackProps) {
   return (
     <div role="alert">
       <p>Something went wrong:</p>
-      <pre>{error.message}</pre>
+      <pre>
+        {error instanceof Error
+          ? `This is Error Instance: ${error.message}`
+          : `It's not Error Instance: ${error}`}
+      </pre>
       <button onClick={resetErrorBoundary}>Try again</button>
     </div>
   )
@@ -48,7 +52,7 @@ test('handleError forwards along async errors', async () => {
   expect(componentStack).toMatchInlineSnapshot(`
     "The above error occurred in the <AsyncBomb> component:
 
-        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:21:41)
+        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:25:41)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
@@ -94,7 +98,7 @@ test('can pass an error to useErrorHandler', async () => {
   expect(componentStack).toMatchInlineSnapshot(`
     "The above error occurred in the <AsyncBomb> component:
 
-        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:66:37)
+        at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:70:37)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -8,7 +8,11 @@ function ErrorFallback({error, resetErrorBoundary}: FallbackProps) {
   return (
     <div role="alert">
       <p>Something went wrong:</p>
-      <pre>{error.message}</pre>
+      <pre>
+        {error instanceof Error
+          ? `This is Error Instance: ${error.message}`
+          : `It's not Error Instance: ${error}`}
+      </pre>
       <button onClick={resetErrorBoundary}>Try again</button>
     </div>
   )
@@ -56,11 +60,11 @@ test('standard use-case', () => {
   expect(componentStack).toMatchInlineSnapshot(`
     "The above error occurred in the <Bomb> component:
 
-        at Bomb (<PROJECT_ROOT>/src/__tests__/index.tsx:18:9)
+        at Bomb (<PROJECT_ROOT>/src/__tests__/index.tsx:22:9)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at div
         at div
-        at App (<PROJECT_ROOT>/src/__tests__/index.tsx:28:43)
+        at App (<PROJECT_ROOT>/src/__tests__/index.tsx:32:43)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)
@@ -75,7 +79,7 @@ test('standard use-case', () => {
         Something went wrong:
       </p>
       <pre>
-        💥 CABOOM 💥
+        This is Error Instance: 💥 CABOOM 💥
       </pre>
       <button>
         Try again
@@ -161,7 +165,7 @@ test('withErrorBoundary HOC', () => {
   expect(componentStack).toMatchInlineSnapshot(`
     "The above error occurred in one of your React components:
 
-        at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:150:13)
+        at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:154:13)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at withErrorBoundary(Unknown)
 
@@ -177,7 +181,7 @@ test('withErrorBoundary HOC', () => {
   expect(onErrorComponentStack).toMatchInlineSnapshot(`
     Object {
       "componentStack": "
-        at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:150:13)
+        at Boundary.FallbackComponent (<PROJECT_ROOT>/src/__tests__/index.tsx:154:13)
         at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
         at withErrorBoundary(Unknown)",
     }
@@ -394,7 +398,11 @@ test('should support not only function as FallbackComponent', () => {
   const FancyFallback = React.forwardRef(({error}: FallbackProps) => (
     <div>
       <p>Everything is broken. Try again</p>
-      <pre>{error.message}</pre>
+      <pre>
+        {error instanceof Error
+          ? `This is Error Instance: ${error.message}`
+          : `It's not Error Instance: ${error}`}
+      </pre>
     </div>
   ))
   FancyFallback.displayName = 'FancyFallback'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ const changedArray = (a: Array<unknown> = [], b: Array<unknown> = []) =>
   a.length !== b.length || a.some((item, index) => !Object.is(item, b[index]))
 
 interface FallbackProps {
-  error: Error
+  error: unknown
   resetErrorBoundary: (...args: Array<unknown>) => void
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`FallbackProps` type edit

<!-- Why are these changes necessary? -->

**Why**:

In `FallbackProps` , which is the Props Type of  `<ErrorBoundary />` , `error` no longer guarantees an Error object.

This is because you can pass any value through `useErrorHandler()` through #89.

Also, it is semantically clear because the [type of catch is changed to unknown by default in TS 4.4](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables).

<!-- How were these changes implemented? -->

**How**:

Fixed the `FallbackProps` type and updated the snapshot.

<!-- Have you done all of these things?  -->

**Checklist**: Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
