### PR TITLE
feat: allow ReactNode as fallback returns

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,12 +21,7 @@ interface ErrorBoundaryPropsWithComponent {
   fallbackRender?: never
 }
 
-declare function FallbackRender(
-  props: FallbackProps,
-): React.ReactElement<
-  unknown,
-  string | React.FunctionComponent | typeof React.Component
-> | null
+type FallbackRender = (props: FallbackProps) => React.ReactNode
 
 interface ErrorBoundaryPropsWithRender {
   onResetKeysChange?: (
@@ -49,10 +44,7 @@ interface ErrorBoundaryPropsWithFallback {
   onReset?: (...args: Array<unknown>) => void
   onError?: (error: Error, info: {componentStack: string}) => void
   resetKeys?: Array<unknown>
-  fallback: React.ReactElement<
-    unknown,
-    string | React.FunctionComponent | typeof React.Component
-  > | null
+  fallback: React.ReactNode
   FallbackComponent?: never
   fallbackRender?: never
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Extends the type limitation of fallback and fallbackRender return, to allow all kinds of ReactNode content, like arrays, numbers, etc.

<!-- Why are these changes necessary? -->

**Why**:

From the fallback rendering code, I think that ErrorBoundary can actually use arrays and numbers as return content.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
