### PR TITLE
feat: provide error and resetErrorBoundary via context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ react-error-boundary
 - [API](#api)
   - [`ErrorBoundary` props](#errorboundary-props)
   - [`useErrorHandler(error?: unknown)`](#useerrorhandlererror-unknown)
+  - [`useError`](#useerror)
+  - [`useResetErrorBoundary`](#usereseterrorboundary)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -245,9 +247,9 @@ This is required if no `FallbackComponent` or `fallback` prop is provided.
 #### `fallback`
 
 In the spirit of consistency with the `React.Suspense` component, we also
-support a simple `fallback` prop which you can use for a generic fallback. This
-will not be passed any props so you can't show the user anything actually useful
-though, so it's not really recommended.
+support a simple `fallback` prop which you can use for a generic fallback. You
+can call `useError` and `useResetErrorBoundary` to get current `error` and
+`resetErrorBoundary` function.
 
 ```jsx
 const ui = (
@@ -316,7 +318,7 @@ There are two ways to use `useErrorHandler`:
 Here's an example:
 
 ```javascript
-import { useErrorHandler } from 'react-error-boundary'
+import {useErrorHandler} from 'react-error-boundary'
 
 function Greeting() {
   const [greeting, setGreeting] = React.useState(null)
@@ -360,7 +362,7 @@ function handleSubmit(event) {
 Alternatively, let's say you're using a hook that gives you the error:
 
 ```javascript
-import { useErrorHandler } from 'react-error-boundary'
+import {useErrorHandler} from 'react-error-boundary'
 
 function Greeting() {
   const [name, setName] = React.useState('')
@@ -400,6 +402,65 @@ const ui = (
 
 And now that'll handle your runtime errors as well as the async errors in the
 `fetchGreeting` or `useGreeting` code.
+
+### `useError`
+
+You can get the current error from the `useError` hook.
+
+```jsx
+import {ErrorBoundary, useError} from 'react-error-boundary'
+
+function ErrorView() {
+  const error = useError()
+  return <pre>{error.message}</pre>
+}
+
+const ui = (
+  <ErrorBoundary
+    fallback={
+      <div>
+        Oh no
+        <br />
+        <ErrorView />
+      </div>
+    }
+  >
+    <ComponentThatMayError />
+  </ErrorBoundary>
+)
+```
+
+`useError` only should be used inside `<ErrorBoundary fallback />`.
+
+### `useResetErrorBoundary`
+
+You can get `resetErrorBoundary` function from the `useResetErrorBoundary` hook.
+It will help to create a reusable reset button.
+
+```jsx
+import {ErrorBoundary, useResetErrorBoundary} from 'react-error-boundary'
+
+function ResetButton() {
+  const resetErrorBoundary = useResetErrorBoundary()
+  return <button onClick={resetErrorBoundary}>Try again</button>
+}
+
+const ui = (
+  <ErrorBoundary
+    fallback={
+      <div>
+        Oh no
+        <br />
+        <ResetButton />
+      </div>
+    }
+  >
+    <ComponentThatMayError />
+  </ErrorBoundary>
+)
+```
+
+`resetErrorBoundary` only should be used inside `<ErrorBoundary fallback />`.
 
 ## Issues
 

--- a/src/__tests__/hook.tsx
+++ b/src/__tests__/hook.tsx
@@ -49,7 +49,7 @@ test('handleError forwards along async errors', async () => {
     "The above error occurred in the <AsyncBomb> component:
 
         at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:21:41)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:79:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)
@@ -95,7 +95,7 @@ test('can pass an error to useErrorHandler', async () => {
     "The above error occurred in the <AsyncBomb> component:
 
         at AsyncBomb (<PROJECT_ROOT>/src/__tests__/hook.tsx:66:37)
-        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:72:3)
+        at ErrorBoundary (<PROJECT_ROOT>/src/index.tsx:79:3)
 
     React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary."
   `)


### PR DESCRIPTION
**What**: feature

`<ErrorBoundary fallback />` provides `error` and `resetErrorBoundary` via context and make error and reet accessible via `useError` and `useResetErrorBoundary` hooks for fallback element.

example usage:

```tsx
function ResetButton() {
  const resetErrorBoundary = useResetErrorBoundary()
  return <button onClick={resetErrorBoundary}>Try again</button>
}

function ErrorView() {
  const error = useError()
  return <pre>{error.message}</pre>
}

function App() {
  return (
    <ErrorBoundary
      fallback={
        <div role="alert">
          <p>Oh no</p>
          <ErrorView />
          <ResetButton />
        </div>
      }
    >
      <SomeComponent />
    </ErrorBoundary>
  );
}

```

<!-- Why are these changes necessary? -->

**Why**:

- make the current error and reset accessible for `<ErrorBoundary fallback />`
- make it possible to create reusable reset buttons and error view

<!-- How were these changes implemented? -->

**How**:

with context

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
