### PR TITLE
Re-add sideEffects false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "clear": "npm run clear:parcel-cache & npm run clear:builds & npm run clear:node_modules",
     "clear:builds": "rm -rf ./packages/*/dist",


### PR DESCRIPTION
The 4.0.0 release commit removed the entry to set side effects to false. As far as I can tell this release didn't introduce any side effects, was this by accident?

Link to code diff: https://github.com/bvaughn/react-error-boundary/commit/9a91190e697084800bb93cd42c554118d13aa527#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9

I can't see any side-effectful code from a quick inspection, so it seems safe to re-add this.