### PR TITLE
fix: error boundary use arrow fun case parameter list error

### DIFF
--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -21,13 +21,16 @@ export class ErrorBoundary extends Component<
   PropsWithRef<PropsWithChildren<ErrorBoundaryProps>>,
   ErrorBoundaryState
 > {
-  state = initialState;
+  constructor(props: ErrorBoundaryProps ){
+    super(props);
+    this.state = initialState;
+  }
 
   static getDerivedStateFromError(error: Error) {
     return { didCatch: true, error };
   }
 
-  resetErrorBoundary = (...args: any[]) => {
+  resetErrorBoundary(...args: any[]) {
     const { error } = this.state;
 
     if (error !== null) {
@@ -81,7 +84,7 @@ export class ErrorBoundary extends Component<
     if (didCatch) {
       const props: FallbackProps = {
         error,
-        resetErrorBoundary: this.resetErrorBoundary,
+        resetErrorBoundary: this.resetErrorBoundary.bind(this),
       };
 
       if (isValidElement(fallback)) {
@@ -103,7 +106,7 @@ export class ErrorBoundary extends Component<
         value: {
           didCatch,
           error,
-          resetErrorBoundary: this.resetErrorBoundary,
+          resetErrorBoundary: this.resetErrorBoundary.bind(this),
         },
       },
       childToRender


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
1. ErrorBoundary Component init state in constructor
2. resetErrorBoundary: not use arrow func to bind this

<!-- Why are these changes necessary? -->

**Why**:

in old safari  version  it will case [Unexpected token '='. Expected an opening '(' before a method's parameter list](https://stackoverflow.com/questions/60026651/safari-unexpected-token-expected-an-opening-before-a-methods-paramet) error.

the npm dist code is such as,  but some browser not support arrow function.

```js
class $6d6d4999e62b3ee0$export$e926676385687eaf extends (0, $8zHUo$react.Component) {
    state = $6d6d4999e62b3ee0$var$initialState;
    static getDerivedStateFromError(error) {
        return {
            didCatch: true,
            error: error
        };
    }
    resetErrorBoundary = (...args)=>{
        const { error: error  } = this.state;
        if (error !== null) {
            this.props.onReset?.({
                args: args,
                reason: "imperative-api"
            });
            this.setState($6d6d4999e62b3ee0$var$initialState);
        }
    };

```

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
