### PR TITLE
fix: remove ReactElement casting from render

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,32 +180,4 @@ const ComponentWithErrorBoundary = withErrorBoundary(ExampleComponent, {
 
 ---
 
-# FAQ
-## `ErrorBoundary` cannot be used as a JSX component
-This error can be caused by a version mismatch between [react](https://npmjs.com/package/react) and [@types/react](https://npmjs.com/package/@types/react). To fix this, ensure that both match exactly, e.g.:
-
-If using NPM:
-```json
-{
-  ...
-  "overrides": {
-    "@types/react": "17.0.60"
-  },
-  ...
-}
-```
-
-If using Yarn:
-```json
-{
-  ...
-  "resolutions": {
-    "@types/react": "17.0.60"
-  },
-  ...
-}
-```
-
----
-
 [This blog post](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react) shows more examples of how this package can be used, although it was written for the [version 3 API](https://github.com/bvaughn/react-error-boundary/releases/tag/v3.1.4).

--- a/README.md
+++ b/README.md
@@ -180,4 +180,32 @@ const ComponentWithErrorBoundary = withErrorBoundary(ExampleComponent, {
 
 ---
 
+# FAQ
+## `ErrorBoundary` cannot be used as a JSX component
+This error can be caused by a version mismatch between [react](https://npmjs.com/package/react) and [@types/react](https://npmjs.com/package/@types/react). To fix this, ensure that both match exactly, e.g.:
+
+If using NPM:
+```json
+{
+  ...
+  "overrides": {
+    "@types/react": "17.0.60"
+  },
+  ...
+}
+```
+
+If using Yarn:
+```json
+{
+  ...
+  "resolutions": {
+    "@types/react": "17.0.60"
+  },
+  ...
+}
+```
+
+---
+
 [This blog post](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react) shows more examples of how this package can be used, although it was written for the [version 3 API](https://github.com/bvaughn/react-error-boundary/releases/tag/v3.1.4).

--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -112,7 +112,7 @@ export class ErrorBoundary extends Component<
         },
       },
       childToRender
-    ) as ReactElement;
+    );
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

closes #145

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Remove type casting in ErrorBoundary.prototype.render
- ~~Remove outdated warning in README~~

<!-- Why are these changes necessary? -->

**Why**:

For whatever reason (I didn't want to invest much time into debugging React types), `ReactElement` returned from class component render function is not compatible with JSX declarations.

My change is removing the explicit type, which makes it fall back to the inferred type
```ts
ErrorBoundary.render(): React.FunctionComponentElement<React.ProviderProps<ErrorBoundaryContextType | null>>
```

I've seen this commit 63339c36f7ff6e16a9648f4d0afea085cb69bb2a, which added `as ReactElement` in the first place. However, after short investigation, I noticed that the distributed files don't suffer from the original problem of broken import paths. So I assumed it is safe to roll it back to previous state.

<!-- How were these changes implemented? -->

**How**:

?

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
