### PR TITLE
chore: use .nvmrc as source of actions/setup-node@v3's following version

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - uses: pnpm/action-setup@v2
         with:
           version: 7

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - uses: pnpm/action-setup@v2
         with:
           version: 7

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - uses: pnpm/action-setup@v2
         with:
           version: 7


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: .nvmrc as source of actions/setup-node@v3's following version

<!-- Why are these changes necessary? -->

**Why**: actions/setup-node@v3 will use just latest node-version. but this project use exact node version, as written in .nvmrc

<!-- How were these changes implemented? -->

**How**: use actions/setup-node@v3's option node-version-file

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
