### PR TITLE
fix: ErrorBoundarySharedProps's info type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ComponentType,
+  ErrorInfo,
   FunctionComponent,
   PropsWithChildren,
   ReactElement,
@@ -15,7 +16,7 @@ export type FallbackProps = {
 };
 
 type ErrorBoundarySharedProps = PropsWithChildren<{
-  onError?: (error: Error, info: { componentStack: string }) => void;
+  onError?: (error: Error, info: ErrorInfo) => void;
   onReset?: (
     details:
       | { reason: "imperative-api"; args: any[] }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fix ErrorBoundarySharedProps's info type

<!-- Why are these changes necessary? -->

**Why**: ErrorBoundarySharedProps's info can follow ErrorInfo of react

<!-- How were these changes implemented? -->

**How**: connect ErrorBoundary.onError.info to React.ErrorInfo

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
