### PR TITLE
fix: remove unnecessary PropsWithRef type

### DIFF
--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  createElement,
-  ErrorInfo,
-  isValidElement,
-  PropsWithRef,
-} from "react";
+import { Component, createElement, ErrorInfo, isValidElement } from "react";
 import { ErrorBoundaryContext } from "./ErrorBoundaryContext";
 import { ErrorBoundaryProps, FallbackProps } from "./types";
 
@@ -16,7 +10,7 @@ const initialState: ErrorBoundaryState = {
 };
 
 export class ErrorBoundary extends Component<
-  PropsWithRef<ErrorBoundaryProps>,
+  ErrorBoundaryProps,
   ErrorBoundaryState
 > {
   constructor(props: ErrorBoundaryProps) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: remove unnecessary PropsWithRef type

<!-- Why are these changes necessary? -->

**Why**: because `PropsWithRef` is not necessary internally, externally

<!-- How were these changes implemented? -->

**How**: remove unnecessary `PropsWithRef` type

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


### PropsWithRef
This `PropsWithRef` type just exclude string ref. I made [why this `PropsWithRef` is unnecessary example link](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzlApgOwCYqnAvnAMyghDgCJUBDAYxgFoMSyBuAKFEljgCUUaYANIlZw4AYRKQ06GAAViYAM5CJ4CNLRyFigOrAYACwgBXGLwJD5EJXsPnW+IiXJVaLVh5gBPMCjiyAQTgAXnFJdRkrJQAeMgxgADcyAD42b19-ACEQsLUNLWtdfSNTc1j4pNSPanVFeDAARgAufyDQpFQCFrI6qGA0AHMyPDYatDq4MAAmFqiiuxQCaMDknI7F7t7+oZHWMYmwAGZZ7VsDMpW15A24aioYFHMACgBKXf36gBYTwrOLzNW7WuXVu90ei1eIyAA).

You can check `ErrorBoundaryProps` have no ref. so `PropsWithRef` have no ref type to exclude. so I removed unnecessary `PropsWithRef`. there is no difference for internal one or external one.

```ts
    /** Ensures that the props do not include string ref, which cannot be forwarded */
    type PropsWithRef<P> =
        // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.
        'ref' extends keyof P
            ? P extends { ref?: infer R | undefined }
                ? string extends R
                    ? PropsWithoutRef<P> & { ref?: Exclude<R, string> | undefined }
                    : P
                : P
            : P;
```

