### PR TITLE
fix: propagate original error

### DIFF
--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -1,3 +1,4 @@
+import { isDevelopment } from "#is-development";
 import { Component, createElement, ErrorInfo, isValidElement } from "react";
 import { ErrorBoundaryContext } from "./ErrorBoundaryContext";
 import { ErrorBoundaryProps, FallbackProps } from "./types";
@@ -88,9 +89,12 @@ export class ErrorBoundary extends Component<
       } else if (FallbackComponent) {
         childToRender = createElement(FallbackComponent, props);
       } else {
-        console.error(
-          "react-error-boundary requires either a fallback, fallbackRender, or FallbackComponent prop"
-        );
+        if (isDevelopment) {
+          console.error(
+            "react-error-boundary requires either a fallback, fallbackRender, or FallbackComponent prop"
+          );
+        }
+
         throw error;
       }
     }

--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -88,9 +88,10 @@ export class ErrorBoundary extends Component<
       } else if (FallbackComponent) {
         childToRender = createElement(FallbackComponent, props);
       } else {
-        throw new Error(
+        console.error(
           "react-error-boundary requires either a fallback, fallbackRender, or FallbackComponent prop"
         );
+        throw error;
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Per the conversation in https://github.com/bvaughn/react-error-boundary/issues/159, it would be great if we propagated the original error, when no type of fallback is provided. This PR addresses that.

> Additionally I opted to log a `console.error` to guide the developer in understanding the issue. Unsure if this affects react server components in any way. 

**How**:

Just threw the original error back.

> The one **potential** breaking change here is that there's no longer an expectation that this component throws an `Error` type as the error itself could be anything.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - N/A
- [x] Tests - Validated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
