### PR TITLE
fix(useErrorBoundary): state type narrow

### DIFF
--- a/src/useErrorBoundary.ts
+++ b/src/useErrorBoundary.ts
@@ -2,6 +2,10 @@ import { useContext, useMemo, useState } from "react";
 import { assertErrorBoundaryContext } from "./assertErrorBoundaryContext";
 import { ErrorBoundaryContext } from "./ErrorBoundaryContext";
 
+type UseErrorBoundaryState<Error> =
+  | { error: Error; hasError: true }
+  | { error: null; hasError: false };
+
 export type UseErrorBoundaryApi<Error> = {
   resetBoundary: () => void;
   showBoundary: (error: Error) => void;
@@ -12,10 +16,7 @@ export function useErrorBoundary<Error = any>(): UseErrorBoundaryApi<Error> {
 
   assertErrorBoundaryContext(context);
 
-  const [state, setState] = useState<{
-    error: Error | null;
-    hasError: boolean;
-  }>({
+  const [state, setState] = useState<UseErrorBoundaryState<Error>>({
     error: null,
     hasError: false,
   });

--- a/src/useErrorBoundary.ts
+++ b/src/useErrorBoundary.ts
@@ -2,21 +2,21 @@ import { useContext, useMemo, useState } from "react";
 import { assertErrorBoundaryContext } from "./assertErrorBoundaryContext";
 import { ErrorBoundaryContext } from "./ErrorBoundaryContext";
 
-type UseErrorBoundaryState<Error> =
-  | { error: Error; hasError: true }
+type UseErrorBoundaryState<TError> =
+  | { error: TError; hasError: true }
   | { error: null; hasError: false };
 
-export type UseErrorBoundaryApi<Error> = {
+export type UseErrorBoundaryApi<TError> = {
   resetBoundary: () => void;
-  showBoundary: (error: Error) => void;
+  showBoundary: (error: TError) => void;
 };
 
-export function useErrorBoundary<Error = any>(): UseErrorBoundaryApi<Error> {
+export function useErrorBoundary<TError = any>(): UseErrorBoundaryApi<TError> {
   const context = useContext(ErrorBoundaryContext);
 
   assertErrorBoundaryContext(context);
 
-  const [state, setState] = useState<UseErrorBoundaryState<Error>>({
+  const [state, setState] = useState<UseErrorBoundaryState<TError>>({
     error: null,
     hasError: false,
   });
@@ -27,7 +27,7 @@ export function useErrorBoundary<Error = any>(): UseErrorBoundaryApi<Error> {
         context?.resetErrorBoundary();
         setState({ error: null, hasError: false });
       },
-      showBoundary: (error: Error) =>
+      showBoundary: (error: TError) =>
         setState({
           error,
           hasError: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I type-narrowed useErrorBoundary's state

<!-- Why are these changes necessary? -->

**Why**: I want to express state type clearly

<!-- How were these changes implemented? -->

**How**: described in below code

### AS IS

```ts
type UseErrorBoundaryState = {
    error: Error | null;
    hasError: boolean;
  };
```

### TO BE

```ts
type UseErrorBoundaryState<Error> =
  | { error: Error; hasError: true }
  | { error: null; hasError: false };
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
