### PR TITLE
FallbackProps as generic, so we can inject desired type without breaking change

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ import {
 
 declare function FallbackRender(props: FallbackProps): ReactNode;
 
-export type FallbackProps = {
-  error: any;
+export type FallbackProps<T = any> = {
+  error: T;
   resetErrorBoundary: (...args: any[]) => void;
 };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: FallbackProps as a generic that has any default, instead of any

<!-- Why are these changes necessary? -->

**Why**: I came across an issue where I'm using fallbackRender : its argument has an any type, so I could not use it with custom errors (e.g. returning an object) in JSX to fit (react/prop-types eslint rule).

Before: 
```
<ErrorBoundary
    fallbackRender={(props) => {
      return (
        <MainWrapper layout="default">
          <Alert
            severity="error"
            title="Erreur"
            description={props.error.message} // 'error' is missing in props validationeslint[react/prop-types](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prop-types.md)
          />
        </MainWrapper>
      );
    }}
  >
    {children}
  </ErrorBoundary>
 ```

After: 
```
<ErrorBoundary
    fallbackRender={(props: FallbackProps<ClientError>) => {
      const { error } = props;
      return (
        <MainWrapper layout="default">
          <Alert
            severity="error"
            title="Erreur"
            description={error.message}
          />
        </MainWrapper>
      );
    }}
  >
    {children}
  </ErrorBoundary>
 ```

I guess we could go further and infer type, but this is a quick fix that doesn't break anything.