### PR TITLE
change the script from npm to pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clear": "npm run clear:builds & npm run clear:node_modules",
+    "clear": "pnpm clear:builds & pnpm clear:node_modules",
     "clear:builds": "rm -rf ./dist",
     "clear:node_modules": "rm -rf ./node_modules",
     "prerelease": "preconstruct build",


### PR DESCRIPTION
**What**: Change package.json's scripts

**Why**: The use of "npm" in projects using the "pnpm" package manager is awkward and confusing.

**How**: Replace "npm run" with "pnpm"

**Checklist**:

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
