### PR TITLE
fix: fix #189 remove the redundant uncaught error and error stack trace from the console

### DIFF
--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -18,6 +18,15 @@ const initialState: ErrorBoundaryState = {
   error: null,
 };
 
+const originalConsoleError = console.error;
+
+window.addEventListener("error", (event) => {
+  if (event.error.isShowBoundary) {
+    event.preventDefault();
+    console.error = () => {};
+  }
+});
+
 export class ErrorBoundary extends Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -48,6 +57,7 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     this.props.onError?.(error, info);
+    console.error = originalConsoleError;
   }
 
   componentDidUpdate(

--- a/src/ErrorBoundaryContext.ts
+++ b/src/ErrorBoundaryContext.ts
@@ -4,6 +4,8 @@ export type ErrorBoundaryContextType = {
   didCatch: boolean;
   error: any;
   resetErrorBoundary: (...args: any[]) => void;
+  suppressLogging: boolean;
+  handleSuppressLogging: (event: ErrorEvent) => void;
 };
 
 export const ErrorBoundaryContext =

--- a/src/assertErrorBoundaryContext.ts
+++ b/src/assertErrorBoundaryContext.ts
@@ -6,7 +6,9 @@ export function assertErrorBoundaryContext(
   if (
     value == null ||
     typeof value.didCatch !== "boolean" ||
-    typeof value.resetErrorBoundary !== "function"
+    typeof value.resetErrorBoundary !== "function" ||
+    typeof value.suppressLogging !== "boolean" ||
+    typeof value.handleSuppressLogging !== "function"
   ) {
     throw new Error("ErrorBoundaryContext not found");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ type ErrorBoundarySharedProps = PropsWithChildren<{
       | { reason: "keys"; prev: any[] | undefined; next: any[] | undefined }
   ) => void;
   resetKeys?: any[];
+  suppressLogging?: boolean;
 }>;
 
 export type ErrorBoundaryPropsWithComponent = ErrorBoundarySharedProps & {

--- a/src/useErrorBoundary.ts
+++ b/src/useErrorBoundary.ts
@@ -3,8 +3,8 @@ import { assertErrorBoundaryContext } from "./assertErrorBoundaryContext";
 import { ErrorBoundaryContext } from "./ErrorBoundaryContext";
 
 type StateError<TError> =
-  | (TError & { _suppressLogging: true })
-  | (Error & { _suppressLogging: true });
+  | (TError & { _suppressLogging: boolean })
+  | (Error & { _suppressLogging: boolean });
 
 type UseErrorBoundaryState<TError> =
   | { error: StateError<TError>; hasError: true }
@@ -15,36 +15,39 @@ export type UseErrorBoundaryApi<TError> = {
   showBoundary: (error: TError) => void;
 };
 
-function suppressLoggingForError<TError>(error: TError): StateError<TError> {
-  if (error != null) {
-    switch (typeof error) {
-      case "object": {
-        if (Object.isExtensible(error)) {
-          (error as StateError<TError>)._suppressLogging = true;
-          return error as StateError<TError>;
-        } else {
-          return Object.assign(Object.create(error as object), {
-            _suppressLogging: true as true,
-          });
-        }
-      }
-      default: {
-        return Object.assign(Error(error as string), {
-          _suppressLogging: true as true,
-        });
-      }
-    }
-  } else {
-    return Object.assign(Error(undefined), {
-      _suppressLogging: true as true,
-    });
-  }
-}
-
 export function useErrorBoundary<TError = any>(): UseErrorBoundaryApi<TError> {
   const context = useContext(ErrorBoundaryContext);
 
   assertErrorBoundaryContext(context);
+
+  const suppressLoggingForError = function <TError>(
+    error: TError
+  ): StateError<TError> {
+    const suppressLogging = {
+      _suppressLogging: context.suppressLogging as boolean,
+    };
+    if (error != null) {
+      switch (typeof error) {
+        case "object": {
+          if (Object.isExtensible(error)) {
+            (error as StateError<TError>)._suppressLogging =
+              context.suppressLogging;
+            return error as StateError<TError>;
+          } else {
+            return Object.assign(
+              Object.create(error as object),
+              suppressLogging
+            );
+          }
+        }
+        default: {
+          return Object.assign(Error(error as string), suppressLogging);
+        }
+      }
+    } else {
+      return Object.assign(Error(undefined), suppressLogging);
+    }
+  };
 
   const [state, setState] = useState<UseErrorBoundaryState<TError>>({
     error: null,
@@ -58,6 +61,9 @@ export function useErrorBoundary<TError = any>(): UseErrorBoundaryApi<TError> {
         setState({ error: null, hasError: false });
       },
       showBoundary: (error: TError) => {
+        if (context.suppressLogging) {
+          window.addEventListener("error", context.handleSuppressLogging);
+        }
         setState({
           error: suppressLoggingForError(error),
           hasError: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixing #189 

<!-- Why are these changes necessary? -->

**Why**: By removing the redundant message in the console, it will improve developer experience and reduce the chance of causing confusion.

<!-- How were these changes implemented? -->

**How**: I add a *isShowBoundary* property to the *error* prop in the state encapsulated in `useErrorBoundary.ts`. Then in `ErrorBoundary.ts`, I add an event listener to the window object listening to the "error" event. If the *isShowBoundary* flag is `true`, then the default event will be prevented, and the console.error method will be overridden, either. In the *componentDidCatch* method, the original console.error method will be recovered.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Since I needed to put an additional property to an object (the error prop in the state), I did need to modify the type of the original object. I tried my best to imitate the style of the code. Please feel free to comment on the style. Thanks.
