### PR TITLE
feat: change `fallback` prop type to allow `React.ReactNode`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,10 +38,9 @@ export type ErrorBoundaryPropsWithRender = ErrorBoundarySharedProps & {
 };
 
 export type ErrorBoundaryPropsWithFallback = ErrorBoundarySharedProps & {
-  fallback: ReactElement<
-    unknown,
-    string | FunctionComponent | typeof Component
-  > | null;
+  fallback:
+    | Exclude<ReactNode, ReactElement>
+    | ReactElement<unknown, string | FunctionComponent | typeof Component>;
   FallbackComponent?: never;
   fallbackRender?: never;
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Changed the `fallback` prop type to allow `React.ReactNode`

<!-- Why are these changes necessary? -->

**Why**: The other types, `fallbackRender` and `FallbackComponent` **both** return `React.ReactNode`. Not allowing `React.ReactNode` in `fallback` forces developers to use redundant `React.Fragments` components to wrap what `React.ReactNode` permits and creates redundant elements in the component tree. For example:

```tsx
<ErrorBoundary fallback={<>Something bad happened</>}>{children}</ErrorBoundary>
```

could simply be:

```tsx
<ErrorBoundary fallback='Something bad happened'>{children}</ErrorBoundary>
```

<!-- How were these changes implemented? -->

**How**: Modified the type definitions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- Documentation N/A
- Tests N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
