### PR TITLE
chore(.github/workflows/ci.yml): remove version field in with of pnpm/action-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.6.0
       - uses: actions/setup-node@v4
         with:
           cache: "pnpm"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

* removed the `version` specified in the `with` field of `pnpm/action-setup`.

**Why**:

<!-- How were these changes implemented? -->

* [pnpm/action-setup automatically recognizes the pnpm version defined in the packageManager field of package.json](https://github.com/pnpm/action-setup/tree/v4/?tab=readme-ov-file#version). specifying the version in the with field is redundant, adds unnecessary complexity, and increases maintenance overhead. relying on the `packageManager` field ensures simplicity and consistency.

**How**:

<!-- Have you done all of these things?  -->

* removed the version field from the with configuration in `.github/workflows/ci.yml`. the pnpm version will now be derived directly from the `packageManager` field in `package.json`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
