### PR TITLE
fix: modify children type in ErrorBoundarySharedProps

### DIFF
--- a/src/ErrorBoundary.test.tsx
+++ b/src/ErrorBoundary.test.tsx
@@ -60,7 +60,9 @@ describe("ErrorBoundary", () => {
       errorBoundaryRef = createRef<ErrorBoundary>();
     });
 
-    function render(props: Omit<ErrorBoundaryPropsWithFallback, "fallback">) {
+    function render(
+      props: Omit<ErrorBoundaryPropsWithFallback, "fallback" | "children">
+    ) {
       act(() => {
         root.render(
           <ErrorBoundary {...props} fallback="Error" ref={errorBoundaryRef}>
@@ -120,7 +122,7 @@ describe("ErrorBoundary", () => {
 
   describe('"fallback" element', () => {
     function render(
-      props: Omit<ErrorBoundaryPropsWithFallback, "fallback"> = {}
+      props: Omit<ErrorBoundaryPropsWithFallback, "fallback" | "children"> = {}
     ) {
       act(() => {
         root.render(
@@ -169,7 +171,10 @@ describe("ErrorBoundary", () => {
       | null = null;
 
     function render(
-      props: Omit<ErrorBoundaryPropsWithComponent, "FallbackComponent"> = {}
+      props: Omit<
+        ErrorBoundaryPropsWithComponent,
+        "FallbackComponent" | "children"
+      > = {}
     ) {
       act(() => {
         root.render(
@@ -236,7 +241,10 @@ describe("ErrorBoundary", () => {
     let fallbackRender: Mock<(props: FallbackProps) => ReactElement>;
 
     function render(
-      props: Omit<ErrorBoundaryPropsWithRender, "fallbackRender"> = {}
+      props: Omit<
+        ErrorBoundaryPropsWithRender,
+        "fallbackRender" | "children"
+      > = {}
     ) {
       act(() => {
         root.render(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,12 @@
-import { ComponentType, ErrorInfo, PropsWithChildren, ReactNode } from "react";
+import { ComponentType, ErrorInfo, ReactNode } from "react";
 
 export type FallbackProps = {
   error: any;
   resetErrorBoundary: (...args: any[]) => void;
 };
 
-type ErrorBoundarySharedProps = PropsWithChildren<{
+type ErrorBoundarySharedProps = {
+  children: ReactNode;
   onError?: (error: Error, info: ErrorInfo) => void;
   onReset?: (
     details:
@@ -13,7 +14,7 @@ type ErrorBoundarySharedProps = PropsWithChildren<{
       | { reason: "keys"; prev: any[] | undefined; next: any[] | undefined }
   ) => void;
   resetKeys?: any[];
-}>;
+};
 
 export type ErrorBoundaryPropsWithComponent = ErrorBoundarySharedProps & {
   fallback?: never;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Modify children type in ErrorBoundarySharedProps

<!-- Why are these changes necessary? -->

**Why**:

When considering the use case of ErrorBoundary, I don't think it's clear that the `children` type should be treated as optional.

```ts
// Hmm... I don't think I'll use it like this. 🤔
<ErrorBoundary {...propsWihtoutChildren} />
<ErrorBoundary>/* There are no child components. */</ErrorBoundary>

// Yes, this is how you normally use it! 😁
<ErrorBoundary {...props}>
  <Child />
<ErrorBoundary />
```

Is there a reason why `PropsWithChildren` is used to treat the children type as optional?

```ts
type PropsWithChildren<P = unknown> = P & {
  children?: ReactNode | undefined;
}
```

Please let me know if I missed anything!

## Suggestion
```ts
// as-is
type ErrorBoundarySharedProps = PropsWithChildren<{
  onError?: (error: Error, info: ErrorInfo) => void;
  onReset?: (
    details:
      | { reason: "imperative-api"; args: any[] }
      | { reason: "keys"; prev: any[] | undefined; next: any[] | undefined }
  ) => void;
  resetKeys?: any[];
}>;

// to-be
type ErrorBoundarySharedProps = {
  children: ReactNode;
  onError?: (error: Error, info: ErrorInfo) => void;
  onReset?: (
    details:
      | { reason: "imperative-api"; args: any[] }
      | { reason: "keys"; prev: any[] | undefined; next: any[] | undefined }
  ) => void;
  resetKeys?: any[];
};
```

I would appreciate your feedback! 🙏👍 @bvaughn 

<!-- How were these changes implemented? -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
