### PR TITLE
Add test coverage for error re-catch after reset

### DIFF
--- a/lib/components/ErrorBoundary.test.tsx
+++ b/lib/components/ErrorBoundary.test.tsx
@@ -155,6 +155,15 @@ describe("ErrorBoundary", () => {
       expect(container.textContent).toBe("Content");
     });
 
+    it("should catch errors thrown again after reset", () => {
+      shouldThrow = true;
+      render({ resetKeys: [1] });
+      expect(container.textContent).toBe("Error");
+
+      render({ resetKeys: [2] });
+      expect(container.textContent).toBe("Error");
+    });
+
     it("should render a null fallback if specified", () => {
       shouldThrow = true;
       act(() => {
@@ -359,6 +368,5 @@ describe("ErrorBoundary", () => {
   });
 
   // TODO Various cases with resetKeys changing (length, order, etc)
-  // TODO Errors thrown again after reset are caught
   // TODO Nested error boundaries if a fallback throws
 });


### PR DESCRIPTION
Adds a test case for one of the remaining TODO items in ErrorBoundary.test.tsx:

> Errors thrown again after reset are caught

The test verifies that when an error boundary resets (via `resetKeys` change) but the child component continues to throw, the error boundary catches the error again and displays the fallback.

Previously this case had no test coverage.