### PR TITLE
docs: update eslint-react plugin links to npm (repo restructured)

### DIFF
--- a/integrations/vite/README.md
+++ b/integrations/vite/README.md
@@ -31,7 +31,7 @@ export default tseslint.config({
 })
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://www.npmjs.com/package/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://www.npmjs.com/package/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js


### PR DESCRIPTION
The Vite integration README links into `Rel1cx/eslint-react/tree/main/packages/plugins/...` for `eslint-plugin-react-x` and `eslint-plugin-react-dom`. Those paths return 404 — the eslint-react monorepo restructured and the `packages/plugins/` directory no longer exists.

Updated both links to the stable npm package pages (verified live via the registry).