### PR TITLE
fix(ErrorBoundary): reset when the thrown value is null

### DIFF
--- a/lib/components/ErrorBoundary.test.tsx
+++ b/lib/components/ErrorBoundary.test.tsx
@@ -317,25 +317,39 @@ describe("ErrorBoundary", () => {
 
   describe("thrown values", () => {
     let lastRenderedError: unknown | null = null;
+    let lastRenderedResetErrorBoundary:
+      | FallbackProps["resetErrorBoundary"]
+      | null = null;
     let fallbackRender: (props: FallbackProps) => ReactElement;
     let onError: Mock<(...args: unknown[]) => unknown>;
 
     beforeEach(() => {
       lastRenderedError = null;
+      lastRenderedResetErrorBoundary = null;
 
       onError = vi.fn();
 
-      fallbackRender = ({ error }: FallbackProps) => {
+      fallbackRender = ({ error, resetErrorBoundary }: FallbackProps) => {
         lastRenderedError = error;
+        lastRenderedResetErrorBoundary = resetErrorBoundary;
 
         return <div>Error</div>;
       };
     });
 
-    function render() {
+    function render(
+      props: Omit<
+        ErrorBoundaryPropsWithRender,
+        "fallbackRender" | "onError"
+      > = {},
+    ) {
       act(() => {
         root.render(
-          <ErrorBoundary fallbackRender={fallbackRender} onError={onError}>
+          <ErrorBoundary
+            {...props}
+            fallbackRender={fallbackRender}
+            onError={onError}
+          >
             <MaybeThrows>Content</MaybeThrows>
           </ErrorBoundary>,
         );
@@ -364,6 +378,34 @@ describe("ErrorBoundary", () => {
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError.mock.calls[0][0]).toEqual(null);
       expect(container.textContent).toBe("Error");
+    });
+
+    it("should re-render children if a boundary that caught a thrown null is reset via prop", () => {
+      shouldThrow = true;
+      valueToThrow = null;
+
+      render();
+      expect(container.textContent).toBe("Error");
+
+      act(() => {
+        shouldThrow = false;
+        assert(lastRenderedResetErrorBoundary !== null);
+        lastRenderedResetErrorBoundary();
+      });
+
+      expect(container.textContent).toBe("Content");
+    });
+
+    it("should re-render children if a boundary that caught a thrown null is reset reset keys", () => {
+      shouldThrow = true;
+      valueToThrow = null;
+
+      render({ resetKeys: [1] });
+      expect(container.textContent).toBe("Error");
+
+      shouldThrow = false;
+      render({ resetKeys: [2] });
+      expect(container.textContent).toBe("Content");
     });
   });
 

--- a/lib/components/ErrorBoundary.tsx
+++ b/lib/components/ErrorBoundary.tsx
@@ -58,9 +58,9 @@ export class ErrorBoundary extends Component<
   }
 
   resetErrorBoundary(...args: unknown[]) {
-    const { error } = this.state;
+    const { didCatch } = this.state;
 
-    if (error !== null) {
+    if (didCatch) {
       this.props.onReset?.({
         args,
         reason: "imperative-api",
@@ -88,7 +88,7 @@ export class ErrorBoundary extends Component<
 
     if (
       didCatch &&
-      prevState.error !== null &&
+      prevState.didCatch &&
       hasArrayChanged(prevProps.resetKeys, resetKeys)
     ) {
       this.props.onReset?.({


### PR DESCRIPTION
## What

`ErrorBoundary` can't be reset — neither via `resetErrorBoundary()` nor via `resetKeys` — when the thrown value is `null`. Once the fallback is shown it stays there.

## Why

Both reset paths check `error !== null` to decide whether the boundary is currently active:

```ts
// resetErrorBoundary
if (error !== null) { ... }

// componentDidUpdate
if (didCatch && prevState.error !== null && hasArrayChanged(...)) { ... }
```

When null is thrown, getDerivedStateFromError(null) produces { didCatch: true, error: null }, so both guards fail and onReset / setState(initialState) never run. useErrorBoundary().showBoundary(null) followed by resetBoundary() hits the same path.

Only null is affected — the comparison is strict, so undefined, 0, "" etc. reset correctly.

How

- Gate both paths on didCatch (and prevState.didCatch) instead of error !== null. The existing "skip the first componentDidUpdate after an error" behavior is preserved since prevState.didCatch is false on that call.
- Add two tests to the "thrown values" block covering reset via prop and via resetKeys after throwing null. Both fail on main and pass with this change.

The existing "should support thrown null or undefined values" test only covered rendering and onError, which is why this slipped through.