### PR TITLE
Infer the wrapped component's ref type in withErrorBoundary

### DIFF
--- a/lib/utils/withErrorBoundary.test.tsx
+++ b/lib/utils/withErrorBoundary.test.tsx
@@ -1,4 +1,10 @@
-import { Component, createRef, type PropsWithChildren } from "react";
+import {
+  Component,
+  createRef,
+  useImperativeHandle,
+  type PropsWithChildren,
+  type Ref,
+} from "react";
 import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -70,6 +76,32 @@ describe("withErrorBoundary", () => {
     });
 
     const ref = createRef<Inner>();
+
+    act(() => {
+      root.render(<Wrapped foo="abc" ref={ref} />);
+    });
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.test).toBe("function");
+  });
+
+  it("should forward refs to a function component that takes a ref prop", () => {
+    type Handle = { test: () => void };
+
+    function Inner({ foo, ref }: { foo: string; ref?: Ref<Handle> }) {
+      useImperativeHandle(ref, () => ({
+        test() {
+          // No-op
+        },
+      }));
+      return foo;
+    }
+
+    const Wrapped = withErrorBoundary(Inner, {
+      fallback: <div>Error</div>,
+    });
+
+    const ref = createRef<Handle>();
 
     act(() => {
       root.render(<Wrapped foo="abc" ref={ref} />);

--- a/lib/utils/withErrorBoundary.test.tsx
+++ b/lib/utils/withErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import {
   Component,
   createRef,
+  forwardRef,
   useImperativeHandle,
   type PropsWithChildren,
   type Ref,
@@ -9,6 +10,7 @@ import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withErrorBoundary } from "./withErrorBoundary";
+import { assert } from "./assert";
 
 describe("withErrorBoundary", () => {
   let container: HTMLDivElement;
@@ -62,42 +64,46 @@ describe("withErrorBoundary", () => {
   it("should forward refs", () => {
     type Props = { foo: string };
 
-    class Inner extends Component<Props> {
-      test() {
-        // No-op
+    class TestClassComponent extends Component<Props> {
+      getFoo() {
+        return this.props.foo;
       }
       render() {
-        return this.props.foo;
+        return null;
       }
     }
 
-    const Wrapped = withErrorBoundary(Inner, {
+    const Wrapped = withErrorBoundary(TestClassComponent, {
       fallback: <div>Error</div>,
     });
 
-    const ref = createRef<Inner>();
+    const ref = createRef<TestClassComponent>();
 
     act(() => {
       root.render(<Wrapped foo="abc" ref={ref} />);
     });
 
-    expect(ref.current).not.toBeNull();
-    expect(typeof ref.current?.test).toBe("function");
+    assert(ref.current !== null);
+    expect(ref.current.getFoo()).toBe("abc");
   });
 
   it("should forward refs to a function component that takes a ref prop", () => {
-    type Handle = { test: () => void };
+    type Handle = { getFoo: () => string };
 
-    function Inner({ foo, ref }: { foo: string; ref?: Ref<Handle> }) {
+    function TestFunctionComponent({
+      foo,
+      ref,
+    }: {
+      foo: string;
+      ref?: Ref<Handle>;
+    }) {
       useImperativeHandle(ref, () => ({
-        test() {
-          // No-op
-        },
+        getFoo: () => foo,
       }));
       return foo;
     }
 
-    const Wrapped = withErrorBoundary(Inner, {
+    const Wrapped = withErrorBoundary(TestFunctionComponent, {
       fallback: <div>Error</div>,
     });
 
@@ -107,7 +113,33 @@ describe("withErrorBoundary", () => {
       root.render(<Wrapped foo="abc" ref={ref} />);
     });
 
-    expect(ref.current).not.toBeNull();
-    expect(typeof ref.current?.test).toBe("function");
+    assert(ref.current !== null);
+    expect(ref.current.getFoo()).toBe("abc");
+  });
+
+  it("should forward refs to a function using forwardRef", () => {
+    type Handle = { getFoo: () => string };
+
+    const TestForwardRefComponent = forwardRef(
+      ({ foo }: { foo: string }, ref: Ref<Handle>) => {
+        useImperativeHandle(ref, () => ({
+          getFoo: () => foo,
+        }));
+        return null;
+      },
+    );
+
+    const Wrapped = withErrorBoundary(TestForwardRefComponent, {
+      fallback: <div>Error</div>,
+    });
+
+    const ref = createRef<Handle>();
+
+    act(() => {
+      root.render(<Wrapped foo="abc" ref={ref} />);
+    });
+
+    assert(ref.current !== null);
+    expect(ref.current.getFoo()).toBe("abc");
   });
 });

--- a/lib/utils/withErrorBoundary.ts
+++ b/lib/utils/withErrorBoundary.ts
@@ -1,17 +1,22 @@
 import {
   createElement,
   forwardRef,
-  type ComponentClass,
+  type ComponentProps,
+  type ComponentRef,
   type ComponentType,
 } from "react";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import type { ErrorBoundaryProps } from "../types";
 
 export function withErrorBoundary<
-  Type extends ComponentClass<unknown>,
-  Props extends object,
->(Component: ComponentType<Props>, errorBoundaryProps: ErrorBoundaryProps) {
-  const Wrapped = forwardRef<InstanceType<Type>, Props>((props, ref) =>
+  // ComponentProps and ComponentRef are themselves constrained by
+  // JSXElementConstructor<any>, so the parameter they read has to be too.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Type extends ComponentType<any>,
+>(Component: Type, errorBoundaryProps: ErrorBoundaryProps) {
+  type Props = ComponentProps<Type>;
+
+  const Wrapped = forwardRef<ComponentRef<Type>, Props>((props, ref) =>
     createElement(
       ErrorBoundary,
       errorBoundaryProps,


### PR DESCRIPTION
Fixes #248.

`withErrorBoundary` was parameterized over `Type extends ComponentClass<unknown>`, but no parameter mentions `Type`, so it can never be inferred and always falls back to its constraint. Every wrapper came out typed as taking `Ref<Component<unknown, any, any>>`, so passing the ref the wrapped component actually takes fails to compile.

This parameterizes over the component instead, so `Type` is inferred from the argument, and reads both sides off it with `ComponentProps` / `ComponentRef` — matching what the runtime already forwards, and what 6.0.0 declared.

The existing ref test passes a class component, whose instance structurally satisfies `Component<unknown, any, any>`, which is why this survived #211. The added test passes a function component declaring a `ref` prop — the React 19 form — and does not compile without the change.

The constraint needs `any` because React's own `ComponentProps` and `ComponentRef` are constrained by `JSXElementConstructor<any>`; there is a comment and a narrow eslint exception on that line.

Motivation: we hit this upgrading a React 19 CRM frontend off 6.0.0, where it breaks 9 call sites and keeps us pinned.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
